### PR TITLE
Content updates, typography, JSON-LD, and 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 — Mike Privette</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>▋</text></svg>">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&display=swap">
+    <script>
+        (function() {
+            var saved;
+            try { saved = localStorage.getItem('theme'); } catch (e) {}
+            if (saved === 'dark' || saved === 'light') {
+                document.documentElement.setAttribute('data-theme', saved);
+            } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+    <style>
+        :root, [data-theme="dark"] {
+            --bg: #0a0e14;
+            --text: #c9d1d9;
+            --text-bright: #f0f6fc;
+            --text-dim: #6e7681;
+            --accent: #3fb950;
+            --amber: #d29922;
+        }
+        [data-theme="light"] {
+            --bg: #f6f5f0;
+            --text: #3d3b37;
+            --text-bright: #1a1918;
+            --text-dim: #706d66;
+            --accent: #2d7d3a;
+            --amber: #b07d18;
+        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        html { font-size: 18px; }
+        body {
+            font-family: 'JetBrains Mono', monospace;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            line-height: 1.7;
+        }
+        .container { max-width: 480px; padding: 2rem; text-align: left; }
+        .code {
+            font-size: 4rem;
+            font-weight: 700;
+            color: var(--amber);
+            margin-bottom: 0.5rem;
+        }
+        .message {
+            font-size: 1rem;
+            color: var(--text-dim);
+            font-weight: 300;
+            margin-bottom: 1.5rem;
+        }
+        .prompt {
+            font-size: 0.85rem;
+            color: var(--accent);
+        }
+        .prompt::before { content: '~/ '; color: var(--text-dim); }
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 1px solid var(--accent);
+        }
+        a:hover { opacity: 0.8; }
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.01ms !important;
+                transition-duration: 0.01ms !important;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="code">404</div>
+        <div class="message">Nothing here. Path not found.</div>
+        <div class="prompt"><a href="/">cd ~</a></div>
+    </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <!-- Open Graph -->
     <meta property="og:type" content="website">
     <meta property="og:title" content="Mike Privette — Cybersecurity Economist">
-    <meta property="og:description" content="Market intelligence for an opaque industry. Funding analysis, original research, and government briefings on cybersecurity market dynamics.">
+    <meta property="og:description" content="Market intelligence for an opaque industry. Funding analysis, original research, and advisory on cybersecurity market dynamics.">
     <meta property="og:url" content="https://mikeprivette.com/">
     <meta property="og:site_name" content="Mike Privette">
 
@@ -19,7 +19,7 @@
     <meta name="twitter:card" content="summary">
     <meta name="twitter:site" content="@mikepsecuritee">
     <meta name="twitter:title" content="Mike Privette — Cybersecurity Economist">
-    <meta name="twitter:description" content="Market intelligence for an opaque industry. Funding analysis, original research, and government briefings on cybersecurity market dynamics.">
+    <meta name="twitter:description" content="Market intelligence for an opaque industry. Funding analysis, original research, and advisory on cybersecurity market dynamics.">
 
     <!-- Favicon: terminal cursor -->
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>▋</text></svg>">
@@ -28,6 +28,26 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&display=swap">
+
+    <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "name": "Mike Privette",
+        "url": "https://mikeprivette.com",
+        "jobTitle": "Cybersecurity Economist",
+        "description": "Market intelligence for an opaque industry. Funding analysis, original research, and advisory on cybersecurity market dynamics.",
+        "sameAs": [
+            "https://www.linkedin.com/in/mikeprivette/",
+            "https://x.com/mikepsecuritee",
+            "https://github.com/mikeprivette",
+            "https://www.returnonsecurity.com"
+        ],
+        "knowsAbout": ["Cybersecurity", "Market Intelligence", "Venture Capital", "Cybersecurity Economics"],
+        "email": "mike@returnonsecurity.com"
+    }
+    </script>
 
     <!-- Theme detection: runs before paint to prevent FOUC -->
     <script>
@@ -73,7 +93,7 @@
 
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
-        html { font-size: 16px; scroll-behavior: smooth; }
+        html { font-size: 18px; scroll-behavior: smooth; }
 
         body {
             font-family: 'JetBrains Mono', monospace;
@@ -186,11 +206,11 @@
         .section:nth-of-type(5) { animation-delay: 0.7s; }
 
         .section-label {
-            font-size: 0.7rem;
-            font-weight: 500;
+            font-size: 1.1rem;
+            font-weight: 700;
             color: var(--accent);
             text-transform: uppercase;
-            letter-spacing: 0.15em;
+            letter-spacing: 0.1em;
             margin-bottom: 1rem;
         }
 
@@ -230,7 +250,7 @@
 
         .work-title a:hover { color: var(--accent); border-color: var(--accent); }
 
-        .work-desc { font-size: 0.78rem; color: var(--text-dim); font-weight: 300; }
+        .work-desc { font-size: 0.85rem; color: var(--text-dim); font-weight: 300; }
 
         .work-meta { font-size: 0.7rem; color: var(--text-dim); margin-top: 0.35rem; }
 
@@ -254,7 +274,7 @@
         }
 
         .links a {
-            font-size: 0.8rem;
+            font-size: 0.9rem;
             color: var(--text-dim);
             text-decoration: none;
             font-weight: 400;
@@ -271,7 +291,7 @@
         /* Now section */
         .now-item {
             padding: 0.5rem 0;
-            font-size: 0.8rem;
+            font-size: 0.9rem;
             font-weight: 300;
             color: var(--text);
         }
@@ -359,15 +379,16 @@
                 </div>
             </div>
             <div class="work-item">
-                <div class="work-title">Government Briefings</div>
-                <div class="work-desc">Regular market intelligence briefings for GCHQ, NCSC, and allied security organizations on cybersecurity market dynamics and funding trends.</div>
+                <div class="work-title">Advisory &amp; Angel Investing</div>
+                <div class="work-desc">Advising cybersecurity startups and investors on market positioning, go-to-market strategy, and competitive dynamics. Active angel investor in early-stage security companies.</div>
                 <div class="work-meta">
                     <span class="tag">advisory</span>
-                    <span class="tag">policy</span>
+                    <span class="tag">investing</span>
+                    <span class="tag">startups</span>
                 </div>
             </div>
             <div class="work-item">
-                <div class="work-title">AI Security Shared Responsibility Model</div>
+                <div class="work-title"><a href="https://github.com/mikeprivette/ai-security-shared-responsibility" target="_blank" rel="noopener">AI Security Shared Responsibility Model</a></div>
                 <div class="work-desc">Open-source framework for understanding security responsibilities across AI system stakeholders.</div>
                 <div class="work-meta">
                     <span class="tag">open source</span>
@@ -380,7 +401,6 @@
             <h2 class="section-label">Now</h2>
             <div class="now-item">Building data infrastructure to make cybersecurity market intelligence programmable</div>
             <div class="now-item">Writing weekly for 16,000+ subscribers tracking cybersecurity capital flows</div>
-            <div class="now-item">Exploring buy-side M&amp;A advisory for PE firms in cybersecurity</div>
         </section>
 
         <section class="section">
@@ -399,9 +419,7 @@
             </div>
         </section>
 
-        <footer class="footer">
-            <div class="location">Based in London · American abroad · Building in public</div>
-        </footer>
+        <footer class="footer"></footer>
     </div>
 
     <script>


### PR DESCRIPTION
## Summary

- Replace "Government Briefings" work item with "Advisory & Angel Investing"
- Link AI Security SRM title to its GitHub repo
- Remove M&A advisory line from Now section (keep top 2 items)
- Remove footer location text
- Increase base font size (16px → 18px) and bump section labels to proper H2 visual weight
- Add JSON-LD Person schema for structured search data
- Add terminal-themed 404 page matching site aesthetic
- Update OG descriptions to reflect new advisory framing

## Test plan

- [ ] Verify font sizes are noticeably larger, section labels read as H2s
- [ ] Confirm "Advisory & Angel Investing" replaces old government briefings section
- [ ] Confirm AI Security SRM links to https://github.com/mikeprivette/ai-security-shared-responsibility
- [ ] Confirm Now section has only 2 items
- [ ] Confirm footer text is gone
- [ ] Visit /nonexistent-page to verify 404 page renders with matching theme
- [ ] Validate JSON-LD at https://validator.schema.org/

🤖 Generated with [Claude Code](https://claude.ai/code)