### PR TITLE
Widen layout and improve mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,9 +120,9 @@
         }
 
         .container {
-            max-width: 680px;
+            max-width: 780px;
             margin: 0 auto;
-            padding: 3rem 1.5rem 6rem;
+            padding: 3rem 2rem 6rem;
         }
 
         /* Theme toggle */
@@ -340,11 +340,18 @@
             }
         }
 
+        @media (max-width: 768px) {
+            .container { padding: 2.5rem 1.5rem 5rem; }
+            .name { font-size: 1.8rem; }
+        }
+
         @media (max-width: 480px) {
             .container { padding: 2rem 1.25rem 4rem; }
-            .name { font-size: 1.6rem; }
+            .name { font-size: 1.5rem; }
+            .tagline { font-size: 0.8rem; }
             .links { flex-direction: column; gap: 0.75rem; }
             .theme-toggle { top: 0.75rem; right: 0.75rem; }
+            .section-label { font-size: 0.95rem; }
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary

- Widen container from 680px to 780px for better text flow at 18px base font
- Add 768px tablet breakpoint for intermediate screen sizes
- Improve 480px mobile breakpoint with proportional scaling for tagline and section labels

## Test plan

- [ ] Desktop: text should have more room, less cramped line breaks
- [ ] Tablet (~768px): content should still be comfortable with slightly reduced padding
- [ ] Mobile (~480px): tagline, section labels, and name scale down cleanly
- [ ] Links stack vertically on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)