### PR TITLE
fix: update RoS description and remove stale numbers

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,7 +15,7 @@
             <h2 class="section-label">Work</h2>
             <div class="work-item">
                 <div class="work-title"><a href="https://www.returnonsecurity.com" target="_blank" rel="noopener">Return on Security</a></div>
-                <div class="work-desc">Cybersecurity market intelligence — a curated company database, weekly funding analysis, and original research for investors and operators.</div>
+                <div class="work-desc">A weekly newsletter and research platform delivering cybersecurity market intelligence to security leaders worldwide. Funding analysis, original research, and the data the industry lacks.</div>
                 <div class="work-meta">
                     <span class="tag">newsletter</span>
                     <span class="tag">data</span>
@@ -44,7 +44,7 @@
         <section class="section">
             <h2 class="section-label">Now</h2>
             <div class="now-item">Building data infrastructure to make cybersecurity market intelligence programmable</div>
-            <div class="now-item">Publishing weekly analysis on cybersecurity venture funding and market dynamics</div>
+            <div class="now-item">Writing weekly on cybersecurity venture funding and market dynamics</div>
         </section>
 
         <section class="section">


### PR DESCRIPTION
## Summary

- Rewrite Return on Security description to focus on the newsletter and research platform serving security leaders worldwide (not a database of X companies)
- Remove subscriber count from Now section — describe the work, not the metrics
- Remove em dashes and hardcoded numbers that go stale

## Test plan

- [ ] Verify homepage renders correctly with `hugo server -D`

🤖 Generated with [Claude Code](https://claude.com/claude-code)