### PR TITLE
Add subscribe CTA and personal philosophy

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,6 +9,7 @@
             <h2 class="section-label">About</h2>
             <p>I study how money moves through cybersecurity. I spent nearly two decades building and leading security programs at banks, insurers, and enterprises — now I map the market from the outside.</p>
             <p>I run a market intelligence business that sits at the intersection of practitioner knowledge and capital flows. I advise investors, brief governments, and publish the data the industry lacks.</p>
+            <p>I believe technology alone does not solve most problems. Applying the right combination of approach, attitude, and problem-solving is often more important than the technology itself. I like spreadsheets, tinkering with new technologies, and reading about history, science, and philosophy.</p>
         </section>
 
         <section class="section">
@@ -69,6 +70,12 @@
             </div>
         </section>
         {{ end }}
+
+        <section class="section cta-section">
+            <h2 class="section-label">Subscribe</h2>
+            <p>Every week I break down what's happening in cybersecurity markets — who's raising, who's acquiring, and what it means. No hype, no filler. Just the signal.</p>
+            <a href="https://www.returnonsecurity.com/subscribe" target="_blank" rel="noopener" class="cta-button">Subscribe to Return on Security</a>
+        </section>
 
         <section class="section">
             <h2 class="section-label">Elsewhere</h2>

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -149,6 +149,7 @@
     .section:nth-of-type(4) { animation-delay: 0.6s; }
     .section:nth-of-type(5) { animation-delay: 0.7s; }
     .section:nth-of-type(6) { animation-delay: 0.8s; }
+    .section:nth-of-type(7) { animation-delay: 0.9s; }
 
     .section-label {
         font-size: 1.1rem;
@@ -244,6 +245,32 @@
     }
 
     .now-item::before { content: '\25B8 '; color: var(--accent); }
+
+    /* Subscribe CTA */
+    .cta-section p {
+        max-width: 600px;
+    }
+
+    .cta-button {
+        display: inline-block;
+        margin-top: 1rem;
+        padding: 0.65rem 1.5rem;
+        font-family: 'JetBrains Mono', monospace;
+        font-size: 0.85rem;
+        font-weight: 500;
+        color: var(--bg);
+        background: var(--accent);
+        border: 1px solid var(--accent);
+        border-radius: 2px;
+        text-decoration: none;
+        letter-spacing: 0.03em;
+        transition: all 0.2s ease;
+    }
+
+    .cta-button:hover {
+        background: transparent;
+        color: var(--accent);
+    }
 
     /* Blog / Writing styles */
     .post-list { list-style: none; }
@@ -474,5 +501,6 @@
         .article-title { font-size: 1.3rem; }
         .header { margin-bottom: 2.5rem; padding-bottom: 1.75rem; }
         .footer { margin-top: 3rem; }
+        .cta-button { display: block; text-align: center; min-height: 44px; line-height: 44px; padding: 0 1.5rem; }
     }
 </style>


### PR DESCRIPTION
## Summary
- Add personal philosophy paragraph to About section (from original site): technology vs. problem-solving mindset, personal interests
- Add Subscribe call-to-action section with styled button before Elsewhere links
- CTA uses terminal aesthetic: green fill, outline on hover, full-width on mobile

## Test plan
- [ ] About section shows new third paragraph with philosophy and interests
- [ ] Subscribe section appears between Writing/Previously and Elsewhere
- [ ] CTA button links to returnonsecurity.com/subscribe
- [ ] Button hover inverts (green outline, transparent fill)
- [ ] Mobile: button goes full-width with 44px touch target
- [ ] Both dark and light themes render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)